### PR TITLE
Implement SD Card message cache

### DIFF
--- a/include/lemlog/logger/sinks/sd-card.hpp
+++ b/include/lemlog/logger/sinks/sd-card.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lemlog/logger/logger.hpp"
+#include <vector>
 
 namespace logger {
 /**
@@ -8,12 +9,17 @@ namespace logger {
  */
 class SDCard : public Sink {
     public:
-        SDCard(std::string filename = ".log", bool logTimestamp = true);
+        SDCard(std::string filename = ".log", bool logTimestamp = true,
+               int cacheSize = 10);
         void send(Level level, std::string topic, std::string message) override;
     private:
         std::string formatTimestamp(long long ms);
 
+        // cache of messages
+        std::vector<std::string> cache;
+
         std::string filename;
         bool logTimestamp;
+        int cacheSize;
 };
-}
+} // namespace logger


### PR DESCRIPTION
The SD Card cache allows messages to be stored in a vector, instead of being written to the sd card everytime a message is sent. There is a customizable `cacheSize` variable, passed into the ctor which the user can change on creation. Once the cache reaches this size, the entire cache is dumped into the sd card.

Instead of a max size to the cache, maybe there should be a function that manually writes to the card.

Having a cache I believe is the optimal way to write to the SD Card, as repeated writes to it will cause it to disrupt other operations on user code.